### PR TITLE
feat(audit): ContractTrendAnalyzer for cross-session pass-rate regression detection

### DIFF
--- a/gateframe/audit/trend.py
+++ b/gateframe/audit/trend.py
@@ -33,8 +33,6 @@ import statistics
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
-
 
 # ── Data models ───────────────────────────────────────────────────────────────
 

--- a/tests/audit/test_trend.py
+++ b/tests/audit/test_trend.py
@@ -1,17 +1,16 @@
 """Tests for gateframe.audit.trend — ContractTrendAnalyzer."""
 
 import json
-import pytest
 from pathlib import Path
-from gateframe.audit.trend import (
-    ContractTrendAnalyzer,
-    ContractTrend,
-    TrendReport,
-    WorkflowRunSummary,
-    _ols_slope,
-    _direction,
-)
 
+import pytest
+
+from gateframe.audit.trend import (
+    ContractTrend,
+    ContractTrendAnalyzer,
+    _direction,
+    _ols_slope,
+)
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -146,7 +145,7 @@ class TestContractTrendAnalyzer:
         entries = []
         for i in range(10):
             ts = f"2026-04-01T{i:02d}:00:00+00:00"
-            entries.append(_entry("c", True if i < 8 else False, f"run-{i}", ts))
+            entries.append(_entry("c", i < 8, f"run-{i}", ts))
         _write_audit(log, entries)
         report = ContractTrendAnalyzer(log, window=5).analyze()
         ct = report.contract_trends[0]
@@ -170,7 +169,8 @@ class TestContractTrendAnalyzer:
         with log.open("w") as f:
             f.write("not-json\n")
             f.write(json.dumps(_entry("billing", True, "run-1")) + "\n")
-            f.write(json.dumps(_entry("billing", True, "run-2", "2026-04-01T02:00:00+00:00")) + "\n")
+            entry = _entry("billing", True, "run-2", "2026-04-01T02:00:00+00:00")
+            f.write(json.dumps(entry) + "\n")
         report = ContractTrendAnalyzer(log).analyze()
         assert len(report.contract_trends) == 1
 


### PR DESCRIPTION
Closes #1

## Summary

Adds `gateframe.audit.trend.ContractTrendAnalyzer` — reads an existing JSONL audit log written by `JsonFileExporter`, groups entries by `workflow_id`, and computes per-contract OLS pass-rate slopes to detect reliability regressions across workflow runs.

## Motivation (from issue #1)

`JsonFileExporter` already writes an append-mode JSONL audit trail. The data needed for cross-run trend analysis is already there. The missing layer is grouping by **workflow run** and computing whether a contract's pass rate is trending up or down over time.

As clarified in the issue thread: **`window=N` means last N distinct `workflow_id` groups**, not last N raw events — so the slope reflects run-over-run trend, not intra-run noise.

## Usage

```python
from pathlib import Path
from gateframe.audit.trend import ContractTrendAnalyzer

report = ContractTrendAnalyzer(Path('audit.jsonl'), window=20).analyze()

if report.any_regression:
    for ct in report.regressions:
        print(f'{ct.contract_name}: slope={ct.slope:.4f} ({ct.direction})')
        for run in ct.run_summaries[-3:]:
            print(f'  {run.workflow_id}: {run.pass_rate:.1%} ({run.passed}/{run.total})')
```

## Implementation

- **`gateframe/audit/trend.py`** — `ContractTrendAnalyzer`, `TrendReport`, `ContractTrend`, `WorkflowRunSummary`
- **`tests/audit/test_trend.py`** — 19 tests, all passing

### Design constraints
- Reads **existing** `JsonFileExporter` JSONL output — no new data format
- Entries **without** `workflow_id` are silently skipped (backward compat)
- Runs ordered by earliest timestamp within each `workflow_id` group
- OLS via `statistics.linear_regression` (stdlib, **zero new dependencies**)
- **Strictly additive** — no changes to `AuditLog`, `JsonFileExporter`, `AuditEntry`, or CLI

## Tests

```
python -m pytest tests/audit/test_trend.py -v
# 19 passed in 0.20s
```

Test coverage includes: improving/degrading/stable trends, window capping, temporal ordering (by first-seen timestamp), entries without workflow_id, malformed JSONL lines, missing file, multiple contracts, regression threshold boundary.

---

*When `JsonFileExporter` answers "what happened in each validation", `ContractTrendAnalyzer` answers "is this contract getting more or less reliable over time?"*

Reference: [PDR in Production v2.5](https://doi.org/10.5281/zenodo.19362461)