### PR TITLE
feat(context): add reset() method to WorkflowContext

### DIFF
--- a/gateframe/core/context.py
+++ b/gateframe/core/context.py
@@ -119,6 +119,21 @@ class WorkflowContext:
                 penalty += self._silent_fail_penalty
         return penalty
 
+    def reset(self) -> None:
+        """Reset the workflow context to its initial state.
+        
+        This restores confidence to its initial value and clears the history.
+        Useful for reusing a context across multiple runs in tests or
+        long-running processes.
+        """
+        self.confidence = self._initial_confidence
+        self._history.clear()
+        logger.info(
+            "workflow_reset",
+            workflow_id=self.workflow_id,
+            initial_confidence=self._initial_confidence,
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "workflow_id": self.workflow_id,

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -180,6 +180,46 @@ class TestWorkflowContext:
         ctx.update(_make_result(passed=True))
         assert ctx.confidence == 1.0
 
+    def test_reset_restores_confidence(self) -> None:
+        ctx = WorkflowContext("wf1")
+        ctx.update(_make_result(passed=False, failures=[_soft_failure()]))
+        assert ctx.confidence == pytest.approx(0.85)
+        ctx.reset()
+        assert ctx.confidence == 1.0
+
+    def test_reset_clears_history(self) -> None:
+        ctx = WorkflowContext("wf1")
+        ctx.update(_make_result(passed=True))
+        ctx.update(_make_result(passed=False, failures=[_soft_failure()]))
+        assert ctx.step_count == 2
+        ctx.reset()
+        assert ctx.step_count == 0
+        assert ctx.history == []
+
+    def test_reset_with_custom_initial_confidence(self) -> None:
+        ctx = WorkflowContext("wf1", initial_confidence=0.9)
+        ctx.update(_make_result(passed=False, failures=[_soft_failure()]))
+        assert ctx.confidence == pytest.approx(0.75)
+        ctx.reset()
+        assert ctx.confidence == pytest.approx(0.9)
+
+    def test_reset_allows_reuse(self) -> None:
+        ctx = WorkflowContext("wf1")
+        # First run
+        ctx.update(_make_result(passed=False, failures=[_soft_failure()]))
+        ctx.update(_make_result(passed=False, failures=[_soft_failure()]))
+        assert ctx.confidence == pytest.approx(0.70)
+        assert ctx.step_count == 2
+        
+        # Reset and second run
+        ctx.reset()
+        assert ctx.confidence == 1.0
+        assert ctx.step_count == 0
+        
+        ctx.update(_make_result(passed=False, failures=[_silent_failure()]))
+        assert ctx.confidence == pytest.approx(0.9)
+        assert ctx.step_count == 1
+
 
 class TestStepRecord:
     def test_to_dict(self) -> None:


### PR DESCRIPTION
## Summary

This PR adds a `reset()` method to `WorkflowContext` that restores the context to its initial state.

## Changes

- Added `reset()` method to `WorkflowContext` in `gateframe/core/context.py`
- The method restores `confidence` to `_initial_confidence` and clears `_history`
- Added logging for workflow reset events
- Added 4 new test cases covering:
  - Basic reset behavior (confidence restoration)
  - History clearing
  - Custom initial confidence handling
  - Context reuse across multiple runs

## Test Results

All 21 tests pass, including the 4 new tests for the reset functionality.

## Related Issue

Closes #3